### PR TITLE
Delay pmon non-critical daemon

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -2,6 +2,7 @@
     "skip_ledd": true,
     "skip_fancontrol": true,
     "delay_xcvrd": true,
-    "skip_xcvrd_cmis_mgr": true
+    "skip_xcvrd_cmis_mgr": true,
+    "delay_non_critical_daemon": true
 }
 

--- a/dockers/docker-platform-monitor/delay.py
+++ b/dockers/docker-platform-monitor/delay.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# This file serves as a monitor for advanced reboot. 
+# Once it exits, the delayed daemon will initiate.
+
+from swsscommon.swsscommon import RestartWaiter
+RestartWaiter.waitAdvancedBootDone()

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -28,6 +28,15 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 
+{% if delay_non_critical_daemon %}
+[program:delay]
+command=python3 /usr/bin/delay.py
+autostart=false
+autorestart=false
+startsecs=0
+dependent_startup=true
+{% endif %}
+
 {% if not skip_chassisd and IS_MODULAR_CHASSIS == 1 %}
 [program:chassisd]
 command=/usr/local/bin/chassisd
@@ -64,7 +73,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=rsyslogd:running {% if delay_non_critical_daemon %}delay:exited{% endif %}
 {% endif %}
 
 {% if not skip_fancontrol and HAVE_FANCONTROL_CONF == 1 %}
@@ -151,7 +160,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=rsyslogd:running {% if delay_non_critical_daemon %}delay:exited{% endif %}
 {% endif %}
 
 {% if not skip_syseepromd %}
@@ -164,7 +173,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=rsyslogd:running {% if delay_non_critical_daemon %}delay:exited{% endif %}
 {% endif %}
 
 {% if not skip_thermalctld %}
@@ -178,7 +187,7 @@ stderr_logfile=syslog
 startsecs=10
 startretries=50
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=rsyslogd:running {% if delay_non_critical_daemon %}delay:exited{% endif %}
 {% endif %}
 
 {% if not skip_pcied %}
@@ -191,7 +200,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=rsyslogd:running {% if delay_non_critical_daemon %}delay:exited{% endif %}
 {% endif %}
 
 {% if include_sensormond %}
@@ -204,5 +213,5 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=rsyslogd:running {% if delay_non_critical_daemon %}delay:exited{% endif %}
 {% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After this pull request https://github.com/sonic-net/sonic-buildimage/pull/18295 , the pmon has been added to the start list in fast/warm reboot scenarios. However, certain non-critical daemons of pmon could be delayed, resulting in a saving of approximately 1 second in the reboot process. For performance considerations, especially as the current time usage of fast reboot is closer to 30 seconds limitation, this change could ease the pressure.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
add a script as fast/warm reboot monitor and relative supervisord rlues.
once the script exited means the reboot process has ended, other delayed daemon would then initialize.

#### How to verify it
check the fast/warm reboot time usage

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 -->202311
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

