### PR TITLE
[debug] Increase retry times to wait MST device ready

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -184,7 +184,8 @@ function UnlockStateChange() {
 }
 
 function WaitForDevice() {
-    local -i QUERY_RETRY_COUNT_MAX="10"
+    local -i QUERY_RETRY_COUNT_MAX="60"
+    local -i QUERY_RETRY_WARNING="10"
     local -i QUERY_RETRY_COUNT="0"
     local SPC_MST_DEV
     local QUERY_RC=""
@@ -196,7 +197,11 @@ function WaitForDevice() {
         [[ ("${QUERY_RETRY_COUNT}" -lt "${QUERY_RETRY_COUNT_MAX}") && ("${QUERY_RC}" != "${EXIT_SUCCESS}") ]] || break
         sleep 1s
         ((QUERY_RETRY_COUNT++))
-        LogInfo "Retrying MST device query ${QUERY_RETRY_COUNT}"
+        if [[ ("${QUERY_RETRY_COUNT}" -lt "${QUERY_RETRY_WARNING}") ]]; then
+            LogInfo "Retrying MST device query ${QUERY_RETRY_COUNT}"
+        else
+            LogError "Retrying MST device query ${QUERY_RETRY_COUNT}"
+        fi
     done
 
     if [[ "${QUERY_RC}" != "${EXIT_SUCCESS}" ]]; then


### PR DESCRIPTION
The 10s waiting time is not enough occasionally, so increase it to 60s. Error message will be printed once exceed 10s so we can still detect this unnomal behavior even it get ready eventually.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

