### PR TITLE
inner dscp mapping to tc

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/qos.json.j2
@@ -1,6 +1,7 @@
 {#
-    Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES.
-    Apache-2.0
+    SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+    Copyright (c) 2017-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    SPDX-License-Identifier: Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -14,6 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 #}
+
 
 {% if (('type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'LeafRouter') or
        ('type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'ToRRouter') and
@@ -271,9 +273,6 @@
     },
 {%- endmacro %}
 {%- endif %}
-{%- macro generate_global_dscp_to_tc_map() %}
-{# This is an empty macro since the global DSCP_TO_TC map is not required #}
-{%- endmacro %}
 
 {% endif %}
 

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64-remap-disabled.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64-remap-disabled.json
@@ -114,6 +114,9 @@
         }
     },
     "PORT_QOS_MAP": {
+        "global": {
+            "dscp_to_tc_map"  : "AZURE"
+        },
         "Ethernet0": {
             "dscp_to_tc_map"  : "AZURE",
             "tc_to_queue_map" : "AZURE",

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64.json
@@ -180,6 +180,9 @@
         }
     },
     "PORT_QOS_MAP": {
+        "global": {
+            "dscp_to_tc_map"  : "AZURE"
+        },
         "Ethernet0": {
             "dscp_to_tc_map"  : "AZURE_UPLINK",
             "tc_to_queue_map" : "AZURE",

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-d48c40-t0.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-d48c40-t0.json
@@ -287,6 +287,9 @@
         }
     },
     "PORT_QOS_MAP": {
+        "global": {
+            "dscp_to_tc_map"  : "AZURE"
+        },
 
         "Ethernet2": {
 


### PR DESCRIPTION
Previously we disable this table by default as sai doestn't support it. Now they have supported it and we need it to enable inner dscp map to tc feature, so remove the old dummy marco and update testing case accordingly.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

