### PR TITLE
add platform config for leakage detection

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5810_ld-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5810_ld-r0/platform.json
@@ -27,6 +27,27 @@
         "fans": [],
         "fan_drawers": [],
         "psus": [],
+        "leak_sensors": [
+            {
+                "name": "leakage1"
+            },
+            {
+                "name": "leakage2"
+            },
+            {
+                "name": "leakage3"
+            },
+            {
+                "name": "leakage4"
+            },
+            {
+                "name": "leakage5"
+            },
+            {
+                "name": "leakage6"
+            }
+
+        ],
         "thermals": [
             {
                 "name": "ASIC"

--- a/device/mellanox/x86_64-nvidia_sn5810_ld-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5810_ld-r0/pmon_daemon_control.json
@@ -1,6 +1,8 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": true
+    "skip_xcvrd_cmis_mgr": true,
+    "enable_liquid_cooling": true,
+    "liquid_cooling_update_interval": 0.5
 }
 


### PR DESCRIPTION
1. set leakage sensors in plaform.json
2. enable the thread of thermalctld in pmon_daemon_control.json

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

